### PR TITLE
fix: remove build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,12 @@
   "author": "Mike Bannister <mikebannister@gmail.com>",
   "main": "lib/index.js",
   "files": [
-    "lib/index.js"
+    "src/index.js"
   ],
   "license": "MIT",
   "scripts": {
-    "build": "rimraf lib && ./node_modules/.bin/babel src -d lib",
     "test": "ava --verbose src/test.js",
     "dev": "ava --verbose --watch src/test.js",
-    "prepublish": "yarn build",
     "lint": "standard",
     "pretest": "yarn lint"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git"
   },
   "author": "Mike Bannister <mikebannister@gmail.com>",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "files": [
     "src/index.js"
   ],


### PR DESCRIPTION
Do we really need to build this project?

This PR removes the build step, and instead we are setting the main file to `src/index.js`