### PR TITLE
fix: set headers before calling handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,8 +88,8 @@ const cors = (options = {}) => handler => async (req, res, ...restArgs) => {
     setVaryHeader(res, origin)
     res.end()
   } else {
-    const handlerResult = await handler(req, res, ...restArgs)
     setVaryHeader(res, origin)
+    const handlerResult = await handler(req, res, ...restArgs)
     return handlerResult
   }
 }


### PR DESCRIPTION
This fixes an issue when `micro-cors` was trying to set headers after the handler has been called. This resulted in errors being thrown like below.

```
UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT] [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
```

