### PR TITLE
fix: fix test when updating header in handler

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -363,11 +363,11 @@ test('includes Vary header for dynamic origins', async t => {
   }
 })
 
-test('appends Vary header if there is already a value', async t => {
+test('append Vary header', async t => {
   const cors = microCors({ origin: ['foo.com', 'bar.com'] })
   const router = micro(
     cors((req, res) => {
-      res.setHeader('Vary', 'Foo')
+      res.setHeader('Vary', res.getHeader('Vary') + ',Foo')
       return {}
     })
   )
@@ -383,7 +383,7 @@ test('appends Vary header if there is already a value', async t => {
     if (method === 'OPTIONS') {
       t.is(response.headers['vary'], 'Origin')
     } else {
-      t.is(response.headers['vary'], 'Foo,Origin')
+      t.is(response.headers['vary'], 'Origin,Foo')
     }
   }
 })


### PR DESCRIPTION
This fixes a broken test where the `Vary` header wasn't appended.
This was introduced with this change; https://github.com/pudgereyem/micro-cors/pull/3

If the user wants to set a header in the handler they would have to account for already set headers by `micro-cors`.

If we would like for `micro-cors` to take care of the appending headers that are set in the handlers we would have to change the implementation so that the handler calls a callback function that would get picked up by `micro-cors`.

> **Please note that this doesn't break any functionality**, the reality before was that the header that `micro-cors` tried to set before didn't get sent because the response had already ended. As explained in https://github.com/pudgereyem/micro-cors/pull/3